### PR TITLE
Update packages list + fix sources.list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM ubuntu
 MAINTAINER Brandon R. Stoner <monokrome@monokro.me>
 
+RUN apt-get update -y
 RUN apt-get install -y python-software-properties && add-apt-repository -y ppa:ubuntu-wine/ppa
-RUN sed -i 's/main/main universe/' /etc/apt/sources.list && apt-get update -y
+RUN apt-get update -y
 
 RUN apt-get install -y wine1.7 winetricks xvfb
 


### PR DESCRIPTION
Update is required because old versions of packages may not be available at the
time of `docker build`.

Recent versions of ubuntu image already contains `universe` category:

$ sudo docker run ubuntu /bin/cat /etc/apt/sources.list
deb http://archive.ubuntu.com/ubuntu precise main universe
deb http://archive.ubuntu.com/ubuntu precise-updates main universe
deb http://archive.ubuntu.com/ubuntu precise-security main universe
$
