### PR TITLE
Fixes for ubuntu 14.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu
 MAINTAINER Brandon R. Stoner <monokrome@monokro.me>
 
 RUN apt-get update -y
-RUN apt-get install -y python-software-properties && add-apt-repository -y ppa:ubuntu-wine/ppa
+RUN apt-get install -y software-properties-common && add-apt-repository -y ppa:ubuntu-wine/ppa
 RUN apt-get update -y
 
 RUN apt-get install -y wine1.7 winetricks xvfb

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,5 @@ RUN apt-get update -y
 
 RUN apt-get install -y wine1.7 winetricks xvfb
 
-RUN apt-get purge -y python-software-properties
+RUN apt-get purge -y software-properties-common
 RUN apt-get autoclean -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu
 MAINTAINER Brandon R. Stoner <monokrome@monokro.me>
 
+RUN dpkg --add-architecture i386
+
 RUN apt-get update -y
 RUN apt-get install -y software-properties-common && add-apt-repository -y ppa:ubuntu-wine/ppa
 RUN apt-get update -y


### PR DESCRIPTION
Since release of Ubuntu 14.04 LTS default for `ubuntu` Docker image is Ubuntu 14.04 image.

At some point before 14.04 release `add-apt-repository` script moved to other package in Ubuntu.

Also, looks like recent Ubuntu Docker images doesn't include i386 architecture enabled by default.
